### PR TITLE
add Dockerfile for Rocky Linux 9

### DIFF
--- a/backend/Dockerfile.rockylinux
+++ b/backend/Dockerfile.rockylinux
@@ -1,0 +1,56 @@
+FROM rockylinux:9
+
+RUN dnf -y update && \
+  dnf -y install epel-release && \
+  dnf config-manager --set-enabled crb && \
+  dnf -y install \
+  postgresql-devel \
+  git \
+  gcc \
+  gcc-c++ \
+  make \
+  openssl-devel \
+  readline-devel \
+  zlib-devel \
+  libyaml-devel \
+  libffi-devel \
+  gdbm-libs \
+  ncurses-devel \
+  gmp-devel \
+  autoconf \
+  bison \
+  libtool \
+  rust \
+  cargo \
+  tar \
+  bzip2 && \
+  dnf clean all && \
+  rm -rf /var/cache/dnf
+
+ENV RUBY_VERSION=3.3.0
+RUN curl -L https://cache.ruby-lang.org/pub/ruby/3.3/ruby-${RUBY_VERSION}.tar.gz -o ruby-${RUBY_VERSION}.tar.gz && \
+  tar -xzf ruby-${RUBY_VERSION}.tar.gz && \
+  cd ruby-${RUBY_VERSION} && \
+  ./configure --disable-install-doc && \
+  make && \
+  make install && \
+  cd .. && \
+  rm -rf ruby-${RUBY_VERSION} ruby-${RUBY_VERSION}.tar.gz
+
+RUN gem install bundler
+
+ENV PATH="/root/.cargo/bin:${PATH}" \
+  LANG=C.UTF-8 \
+  APP_ROOT=/app
+
+RUN mkdir -p $APP_ROOT
+WORKDIR $APP_ROOT
+
+COPY ./Gemfile ./Gemfile.lock $APP_ROOT/
+RUN bundle install --jobs 4 --retry 3
+
+RUN echo "source /root/.aliases" >> /root/.bashrc
+
+COPY . $APP_ROOT
+
+EXPOSE 3000


### PR DESCRIPTION
```shell
$ dce backend /bin/bash

cat /etc/os-release

NAME="Rocky Linux"
VERSION="9.4 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="9.4"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Rocky Linux 9.4 (Blue Onyx)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
SUPPORT_END="2032-05-31"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
ROCKY_SUPPORT_PRODUCT_VERSION="9.4"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.4"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- バックエンドアプリケーション用の新しいDockerfileを追加しました。Rocky Linux 9イメージに基づいており、RubyおよびRustの開発に必要なツールやライブラリをインストールします。
	- Rubyのバージョン3.3.0を設定し、アプリケーションの依存関係を管理するBundlerをインストールしました。
	- アプリケーションコードをコピーし、ポート3000を公開しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->